### PR TITLE
Fix scraper for new AWS pricing page format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest ruff
+
+      - name: Lint
+        run: ruff check src/ tests/
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/src/parser.py
+++ b/src/parser.py
@@ -42,9 +42,15 @@ REGION_NAME_TO_CODE = {
     # Alternate naming conventions
     "Australia (Sydney)": "ap-southeast-2",
     "Australia (Melbourne)": "ap-southeast-4",
+    # GovCloud
+    "AWS GovCloud (US-East)": "us-gov-east-1",
+    "AWS GovCloud (US-West)": "us-gov-west-1",
     # Local Zones
     "US West (Dallas Local Zone)": "us-west-2-dal-1a",
     "Dallas Local Zone\n(US East N. Virginia)": "us-east-1-dfw-2a",
+    "US East (Dallas) Local Zone": "us-east-1-dfw-2a",
+    "US East (Atlanta) Local Zone": "us-east-1-atl-2a",
+    "US West (Phoenix) Local Zone": "us-west-2-phx-2a",
 }
 
 INSTANCE_TYPE_INFO: dict[str, dict] = {
@@ -75,17 +81,15 @@ INSTANCE_TYPE_INFO: dict[str, dict] = {
 def extract_json_data(html: str) -> list[dict]:
     """Extract JSON data from the pricing page HTML.
 
-    The page embeds pricing data in <script type="application/json"> tags.
-    Each tag contains a structure like:
-    {
-        "data": {
-            "items": [{
-                "fields": {
-                    "jsonData": "{...escaped JSON with table data...}"
-                }
-            }]
-        }
-    }
+    The page embeds pricing data in <script type="application/json"> tags,
+    in one of two formats:
+
+    Old format (pre 2026-04): fields.jsonData holds an escaped JSON string
+    with {"heading": ..., "table": {"rowDefinitions": [...], "items": [...]}}.
+
+    New format (2026-04 onwards): fields holds the table directly as
+    itemHeading, itemTableRowGroups, and itemTableData (the latter two are
+    JSON strings).
     """
     pattern = r'<script type="application/json">(.*?)</script>'
     script_matches = re.findall(pattern, html, re.DOTALL)
@@ -100,43 +104,72 @@ def extract_json_data(html: str) -> list[dict]:
 
         items = outer_data.get("data", {}).get("items", [])
         for item in items:
-            json_data_str = item.get("fields", {}).get("jsonData", "")
-            if not json_data_str:
-                continue
-
-            try:
-                table_data = json.loads(json_data_str)
-            except json.JSONDecodeError:
-                continue
-
-            heading = table_data.get("heading", "")
-            if "Pricing" not in heading:
-                continue
-
-            table = table_data.get("table", {})
-            row_definitions = table.get("rowDefinitions", [])
-            table_items = table.get("items", [])
-
-            row_labels = {row["id"]: row.get("label", "") for row in row_definitions}
-
-            for table_item in table_items:
-                row_id = table_item.get("idProperty", "")
-                instance_type = row_labels.get(row_id, "")
-
-                region = table_item.get("2", "")
-                price = table_item.get("3", "")
-
-                if instance_type and region and price:
-                    all_rows.append(
-                        {
-                            "instance_type": instance_type,
-                            "region": region,
-                            "price": price,
-                            "heading": heading,
-                        }
-                    )
+            fields = item.get("fields", {})
+            if "jsonData" in fields:
+                all_rows.extend(_extract_rows_old_format(fields))
+            elif "itemTableData" in fields:
+                all_rows.extend(_extract_rows_new_format(fields))
 
     return all_rows
+
+
+def _collect_table_rows(
+    heading: str, row_definitions: list[dict], table_items: list[dict]
+) -> list[dict]:
+    """Build row dicts from table row definitions and data items."""
+    rows = []
+    row_labels = {row["id"]: row.get("label", "") for row in row_definitions}
+
+    for table_item in table_items:
+        row_id = table_item.get("idProperty", "")
+        instance_type = row_labels.get(row_id, "")
+
+        region = table_item.get("2", "")
+        price = table_item.get("3", "")
+
+        if instance_type and region and price:
+            rows.append(
+                {
+                    "instance_type": instance_type,
+                    "region": region,
+                    "price": price,
+                    "heading": heading,
+                }
+            )
+
+    return rows
+
+
+def _extract_rows_old_format(fields: dict) -> list[dict]:
+    """Extract rows from the old fields.jsonData format."""
+    try:
+        table_data = json.loads(fields.get("jsonData", ""))
+    except json.JSONDecodeError:
+        return []
+
+    heading = table_data.get("heading", "")
+    if "Pricing" not in heading:
+        return []
+
+    table = table_data.get("table", {})
+    return _collect_table_rows(
+        heading, table.get("rowDefinitions", []), table.get("items", [])
+    )
+
+
+def _extract_rows_new_format(fields: dict) -> list[dict]:
+    """Extract rows from the new itemHeading/itemTableRowGroups/itemTableData format."""
+    heading = fields.get("itemHeading", "")
+    if "Pricing" not in heading:
+        return []
+
+    try:
+        row_definitions = json.loads(fields.get("itemTableRowGroups", "[]"))
+        table_items = json.loads(fields.get("itemTableData", "[]"))
+    except json.JSONDecodeError:
+        return []
+
+    return _collect_table_rows(heading, row_definitions, table_items)
 
 
 def clean_html(text: str) -> str:
@@ -152,7 +185,7 @@ def parse_price_string(price_str: str) -> tuple[float, float]:
     """Parse price string like '$31.464 USD ($3.933 USD)' into (hourly, per_accelerator)."""
     price_str = clean_html(price_str)
 
-    pattern = r"\$?([\d,]+\.?\d*)\s*USD\s*\(\$?([\d,]+\.?\d*)\s*USD\)"
+    pattern = r"\$?([\d,]+\.?\d*)\s*(?:USD\s*)?\(\$?([\d,]+\.?\d*)\s*USD\)"
     match = re.search(pattern, price_str)
     if match:
         hourly = float(match.group(1).replace(",", ""))

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -75,7 +75,7 @@ def main() -> None:
         instance_count = len(data.instance_types)
         total_entries = sum(len(it.pricing) for it in data.instance_types.values())
 
-        print(f"Successfully scraped pricing data:")
+        print("Successfully scraped pricing data:")
         print(f"  - Instance types: {instance_count}")
         print(f"  - Total pricing entries: {total_entries}")
         print(f"  - Output file: {output_path}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,137 @@
+"""Tests for the pricing page parser."""
+
+import json
+
+from src.parser import extract_json_data, parse_price_string, parse_pricing_data
+
+
+def _page_with_fields(fields: dict) -> str:
+    """Wrap item fields in the page's <script type="application/json"> structure."""
+    payload = {"data": {"items": [{"fields": fields}]}}
+    return f'<html><script type="application/json">{json.dumps(payload)}</script></html>'
+
+
+# --- New format (2026-04 onwards): itemHeading / itemTableRowGroups / itemTableData ---
+
+NEW_FORMAT_FIELDS = {
+    "itemHeading": "P6e Pricing",
+    "itemRegionProperty": "region",
+    "itemTableColumns": json.dumps(
+        [
+            {"Heading": "UltraServer Type", "accessor": "1"},
+            {"Heading": "Region", "accessor": "2"},
+            {"Heading": "Effective Hourly Rate", "accessor": "3"},
+            {"Heading": "ACCELERATOR", "accessor": "4"},
+        ]
+    ),
+    "itemTableRowGroups": json.dumps(
+        [
+            {"id": "row1", "idProperty": "idProperty", "label": "u-p6e-gb200x72"},
+            {"id": "row3", "idProperty": "idProperty", "label": "u-p6e-gb200x36"},
+        ]
+    ),
+    "itemTableData": json.dumps(
+        [
+            {
+                "id": 0,
+                "idProperty": "row1",
+                "2": "<p>US East (Dallas) Local Zone</p>\r\n",
+                "3": "<p>$761.904 ($10.582 USD)<br /></p>\r\n",
+                "4": "<p>72 x B200</p>\r\n",
+            },
+            {
+                "id": 1,
+                "idProperty": "row3",
+                "2": "<p>US East (Dallas) Local Zone</p>\r\n",
+                "3": "<p>$380.952 ($10.582 USD)<br /></p>\r\n",
+                "4": "<p>36 x B200</p>\r\n",
+            },
+        ]
+    ),
+}
+
+
+def test_extract_new_format_rows():
+    html = _page_with_fields(NEW_FORMAT_FIELDS)
+    rows = extract_json_data(html)
+    assert len(rows) == 2
+    assert rows[0]["instance_type"] == "u-p6e-gb200x72"
+    assert "Dallas" in rows[0]["region"]
+    assert "$761.904" in rows[0]["price"]
+
+
+def test_extract_new_format_skips_non_pricing_tables():
+    fields = dict(NEW_FORMAT_FIELDS)
+    fields["itemHeading"] = "OS pricing across Instance Types"
+    html = _page_with_fields(fields)
+    assert extract_json_data(html) == []
+
+
+# --- Old format (pre 2026-04): fields.jsonData escaped JSON string ---
+
+OLD_FORMAT_FIELDS = {
+    "jsonData": json.dumps(
+        {
+            "heading": "P5 Pricing",
+            "table": {
+                "rowDefinitions": [
+                    {"id": "row1", "label": "p5.48xlarge"},
+                ],
+                "items": [
+                    {
+                        "idProperty": "row1",
+                        "2": "<p>US East (N. Virginia)</p>",
+                        "3": "<p>$31.464 USD ($3.933 USD)</p>",
+                    }
+                ],
+            },
+        }
+    )
+}
+
+
+def test_extract_old_format_still_supported():
+    html = _page_with_fields(OLD_FORMAT_FIELDS)
+    rows = extract_json_data(html)
+    assert len(rows) == 1
+    assert rows[0]["instance_type"] == "p5.48xlarge"
+
+
+# --- Price string parsing ---
+
+def test_parse_price_with_usd_suffix():
+    assert parse_price_string("$31.464 USD ($3.933 USD)") == (31.464, 3.933)
+
+
+def test_parse_price_without_first_usd_suffix():
+    assert parse_price_string("$761.904 ($10.582 USD)") == (761.904, 10.582)
+
+
+def test_parse_price_single_value():
+    assert parse_price_string("$11.8 USD") == (11.8, 0.0)
+
+
+# --- Region code mapping for regions introduced with the new page ---
+
+def _rows_for_region(region: str) -> list[dict]:
+    return [
+        {
+            "instance_type": "p5e.48xlarge",
+            "region": region,
+            "price": "$47.76 USD ($5.97 USD)",
+            "heading": "P5e Pricing",
+        }
+    ]
+
+
+def test_new_region_names_are_mapped():
+    expected = {
+        "US East (Dallas) Local Zone": "us-east-1-dfw-2a",
+        "US East (Atlanta) Local Zone": "us-east-1-atl-2a",
+        "US West (Phoenix) Local Zone": "us-west-2-phx-2a",
+        "AWS GovCloud (US-East)": "us-gov-east-1",
+        "AWS GovCloud (US-West)": "us-gov-west-1",
+    }
+    for region, code in expected.items():
+        result = parse_pricing_data(_rows_for_region(region))
+        assert result["p5e.48xlarge"].pricing[0].region_code == code, region


### PR DESCRIPTION
## Summary

毎月1日の自動スクレイプが **2026-04-01 以降4回連続で失敗** していました(`No pricing data found in the page`)。原因は AWS 側のページ埋め込みデータ形式の変更です。

### 根本原因
- 料金テーブルが `fields.jsonData`(エスケープJSON文字列)から `fields.itemHeading` / `itemTableRowGroups` / `itemTableData` の直接埋め込みに変更された
- 一部価格表記から最初の `USD` が消えた(例: `$761.904 ($10.582 USD)`)
- 新リージョン名が登場(Atlanta/Phoenix/Dallas Local Zone、AWS GovCloud US-East/West)

### 変更内容
- 新旧両形式に対応した `extract_json_data`(共通ロジックは `_collect_table_rows` に抽出)
- 価格パースの `USD` サフィックスをオプション化
- 新リージョンのコードマッピング追加
- pytest スイート追加(新旧形式・価格パース・リージョンマッピングをカバー)
- PR/main push で lint + テストを回す CI workflow(`test.yml`)追加

### 検証
- 実ページHTMLに対して 69 行 / 13 インスタンスタイプを抽出、unknown リージョン・価格0件なしを確認
- `pytest tests/` 7 passed、`ruff check` クリーン

マージ後に `scrape-pricing.yml` を手動実行すれば `data/pricing.json` が更新されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)